### PR TITLE
fix: anthropic temperature/top_p conflict and workspace dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@layer-ai/core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Core API routes and services for Layer AI",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Anthropic API rejects requests when both `temperature` and `top_p` are specified
- Publishing @layer-ai/core with `workspace:*` dependency breaks external installations
- CI builds fail when using published SDK version instead of workspace reference

## What is the new behavior?

- Anthropic provider now prioritizes `temperature` and only sends `top_p` when temperature is not set
- @layer-ai/core maintains `workspace:*` in repo for CI builds
- Published packages use concrete SDK versions (^0.1.4)
- Bumped @layer-ai/core to v0.1.10 with fixes

## Additional context

- Tested against Railway preview deployment with Claude Opus 4.1
- Verified CI builds pass with workspace dependencies
- Confirmed external installations work with published SDK version